### PR TITLE
Update curve25519-dalek to 3.0.0-lizard2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ hmac = "0.11"
 
 [dependencies.curve25519-dalek]
 features = ["serde", "alloc"]
-version = "2.0.0"
+version = "3"
 git = "https://github.com/signalapp/curve25519-dalek.git"
-branch = "lizard2"
+branch = "3.0.0-lizard2"
 
 [features]
 default = ["u64_backend"]


### PR DESCRIPTION
I noticed that `curve25519-dalek` appears under three forms in our systems. Once `3.2.0` vanilla, once `3.0.0-lizard2`, and once under `lizard2`. I'm pretty sure that Signal-Android and Signal-iOS have the same problem (without the vanilla, I suppose, because you patch that out). This should improve compile times and reduce binary size a bit.

I'm not even sure that `poksho` uses lizard? I'm not familiar with the patch set either way. Maybe these patches should get upstreamed to dalek-25519(-ng)?